### PR TITLE
ci: update the build yaml and jmeter test github action pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,22 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      # - uses: actions/setup-go@v2
-      #   with:
-      #     go-version: 1.19
-
       - uses: actions/checkout@v2
-
-      - run: make verify
 
       - uses: docker/setup-buildx-action@v2
         with: {install: true}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.19
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.19
+      # - uses: actions/setup-go@v2
+      #   with:
+      #     go-version: 1.19
 
       - uses: actions/checkout@v2
 
       - run: make verify
 
-      - run: make build
+      - uses: docker/setup-buildx-action@v2
+        with: {install: true}
+
+      - uses: docker/build-push-action@v4
+        with:
+          tags: assetmantle/node:edge
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            TARGETARCH=amd64
+            BUILDARCH=amd64

--- a/.github/workflows/jmeter-test.yml
+++ b/.github/workflows/jmeter-test.yml
@@ -17,12 +17,15 @@ jobs:
       - uses: docker/setup-buildx-action@v2
         with: {install: true}
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v4
         with:
           tags: assetmantle/node:edge
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            TARGETARCH=amd64
+            BUILDARCH=amd64
 
       - run: make docker-compose
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:latest
-FROM golang:1.18-alpine3.17 as build
+FROM golang:1.19-alpine3.17 as build
 WORKDIR /go/node
 SHELL [ "/bin/sh", "-cex" ]
 RUN --mount=type=cache,target=/var/cache/apk/ \


### PR DESCRIPTION
- update Dockerfile with go1.19.
- update build yaml of github action with go1.19.
- update docker/build-push-action from v3 to v4.